### PR TITLE
Recommend using <p> in place of some <h4> or <h5>

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
       <ul>
       <li>Academic Background</li>
       <h4> <b>Master of Computer Science in Northeastern University</b></h4>
+      <!-- I'd recommend using paragraphs here and in similar places to differentiate instead of h5 -->
       <h5> Coursework: Object-oriented design, Applications of algorithms and data structures, Discrete mathematics</h5>
       <h4> <b>Master of Sustainability Leadership in State University of New York At Buffalo</b></h4>
       <h5> Coursework: Advanced GIS, Environmental modeling, Python, JavaScript, Statistical analysis, Psychological statistics</h5>
@@ -62,6 +63,8 @@
 
       <li>Internship Experience</li>
       <h4> <b>Vaccinate Western New York Program - GIS Research Team Leader</b></h4>
+      <!-- I'd recommend using paragraphs here and in similar places to differentiate instead of h4 so you don't have to make lines like the one
+            above stand out by using <b> -->
       <h4> -Performed a COVID-19 cases distribution prediction and transportation gap analysis, conducted presentation to the Blackstone Inc.</h4>
       <h4> <b>Erie County Department of Environment & Planning - Technical Consultant</b></h4>
       <h4> -Cleaned, processed and visualized 70k+ institutional data with over 30 attributes using Pandas and Numpy, saving an approximate $307,895 management cost.</h4>


### PR DESCRIPTION
Most of the text here is formatted as headings. It think it should instead be that most is formatted as paragraphs, with a few headings to stand out. I think, but I'm not sure, that screen readers and other technology might expect paragraphs where some of the smaller headings are (e.g. where I put comments). Using <p> instead of <h5> and <h4> would mean that you wouldn't have to add tags like <b> to differentiate between a section heading (like Vaccinate) and the contents below it.