### PR TITLE
tel prefix was a good choice

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,6 +116,7 @@
     <p>Contact:</p>
     <address>
       <a href="zxu232@gmail.com">zxu232@gmail.com</a><br>
+      <!-- This inclusion of the tel: prefix was a great choice. -->
       <a href="tel:+1 716-907-0493">(716)-907-0493</a>
     </address>
   </body>


### PR DESCRIPTION
Using the tel: prefix was a great choice. It makes it easier to get in touch and has a neat effect that makes the site seem more professional. I also like the styling that you've done to add the phone before the number!